### PR TITLE
Statistical functions empty dataframe return

### DIFF
--- a/migration/python/relis_statistics_playground.py
+++ b/migration/python/relis_statistics_playground.py
@@ -22,7 +22,7 @@ display_figure(comp_stacked_bar_plots[NominalVariables.bidirectional][NominalVar
 
 display_figure(comp_grouped_bar_plots[NominalVariables.bidirectional][NominalVariables.domain], False)
 
-display_data(comp_chi_squared_tests[NominalVariables.domain][NominalVariables.industrial], True)
+display_data(comp_chi_squared_tests[NominalVariables.venue][NominalVariables.industrial], True)
 
 display_data(comp_spearman_cor_tests[ContinuousVariables.publication_year][ContinuousVariables.targeted_year], True)
 


### PR DESCRIPTION
Statistical functions now return empty dataframes if there's an unmet condition in the function business logic that requires to abort the computation.

This allows to inject a title in the empty dataframes. Users can know which statistical functions returned no data.